### PR TITLE
Only send EOF in writable sessions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -177,7 +177,9 @@ func (app *App) generateHandler() func(w http.ResponseWriter, r *http.Request) {
 
 		go func() {
 			<-exit
-			fio.Write([]byte{4})
+			if app.PermitWrite {
+				fio.Write([]byte{4})
+			}
 			fio.Close()
 			conn.Close()
 			log.Printf("Connection closed: %s", r.RemoteAddr)


### PR DESCRIPTION
Currently EOF is sent to the pty even when read-only mode is requested. This can cause trouble in attached tmux sessions, for example. Since the EOF typically used in shells as a shortcut exit, this can result in undesired disconnects.