### PR TITLE
Added handling of —permit-arguments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --once                                                       Accept only one client and exit on disconnection [$GOTTY_ONCE]
 --config "~/.gotty"                                          Config file path [$GOTTY_CONFIG]
 --version, -v                                                print the version
+--permit-arguments                                           Allow to send arguments like this http://exemple.com:8080/?arg=AAA&arg=BBB
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 		flag{"reconnect", "", "Enable reconnection"},
 		flag{"reconnect-time", "", "Time to reconnect"},
 		flag{"once", "", "Accept only one client and exit on disconnection"},
+		flag{"permit-arguments", "", "Allow to send arguments like this http://exemple.com:8080/?arg=AAA&arg=BBB"},
 	}
 
 	mappingHint := map[string]string{

--- a/resources/gotty.js
+++ b/resources/gotty.js
@@ -1,5 +1,6 @@
 (function() {
     var httpsEnabled = window.location.protocol == "https:";
+    var args = window.location.search;
     var url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws';
     var protocols = ["gotty"];
     var autoReconnect = -1;
@@ -12,8 +13,7 @@
         var pingTimer;
 
         ws.onopen = function(event) {
-            ws.send(gotty_auth_token);
-
+            ws.send(JSON.stringify({ Arguments: args, AuthToken: gotty_auth_token,}));
             pingTimer = setInterval(sendPing, 30 * 1000, ws);
 
             hterm.defaultStorage = new lib.Storage.Local();


### PR DESCRIPTION
Hi,
I do this PR to handle parameters with the `permit-arguments` flag.

Example:
```bash
$> gotty --permit-arguments vim
```
You can pass argument like this : `http://server.exmple.com:8080/?params=file1&params=file2`