### PR TITLE
Add tls client certificate authentication

### DIFF
--- a/.gotty
+++ b/.gotty
@@ -30,6 +30,15 @@
 // [string] Default TLS key file path
 // tls_key_file = "~/.gotty.key"
 
+// [bool] Enable client certificate authentication
+// enable_client_certificate = false
+
+// [string] Client Certificate CA file for validation
+// client_ca_file = "~/.gotty.ca.crt"
+
+// [bool] Enable client certificate validation against the provided CA file
+// enable_client_certificate_verification = false
+
 // [string] Custom index.html file
 // index_file = ""
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --tls, -t                                                    Enable TLS/SSL [$GOTTY_TLS]
 --tls-crt "~/.gotty.key"                                     TLS/SSL crt file path [$GOTTY_TLS_CRT]
 --tls-key "~/.gotty.crt"                                     TLS/SSL key file path [$GOTTY_TLS_KEY]
+--client, -C                                                 Enable Client Certificate [$GOTTY_CLIENT]
+--client-ca-file "~/.gotty.ca.crt"                           Client CA certificate file [$GOTTY_CLIENT_CA_FILE]
+--client-verify                                              Enable verification of client certificate [$GOTTY_CLIENT_VERIFY]
 --index                                                      Custom index file [$GOTTY_INDEX]
 --title-format "GoTTY - {{ .Command }} ({{ .Hostname }})"    Title format of browser window [$GOTTY_TITLE_FORMAT]
 --reconnect                                                  Enable reconnection [$GOTTY_RECONNECT]
@@ -100,6 +103,8 @@ All traffic between the server and clients are NOT encrypted by default. When yo
 ```sh
 openssl req -x509 -nodes -days 9999 -newkey rsa:2048 -keyout ~/.gotty.key -out ~/.gotty.crt
 ```
+
+For added security you can use an SSL/TLS client certificate by enabling it with the `-C` option (this requires the `-t` or `--tls` flag to be set). This requires all client connecting to provide a valid certificate that can be validated (use the `--client-verify` option to make verification mandatory) against the CA file that is provided via the `--client-ca-file` option.
 
 (NOTE: For Safari uses, see [how to enable self-signed certificates for WebSockets](http://blog.marcon.me/post/24874118286/secure-websockets-safari) when use self-signed certificates)
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ func main() {
 		flag{"tls", "t", "Enable TLS/SSL"},
 		flag{"tls-crt", "", "TLS/SSL crt file path"},
 		flag{"tls-key", "", "TLS/SSL key file path"},
+		flag{"client", "C", "Enable Client Certificate"},
+		flag{"client-ca-file", "", "Client CA certificate file"},
+		flag{"client-verify", "", "Enable verification of client certificate"},
 		flag{"index", "", "Custom index.html file"},
 		flag{"title-format", "", "Title format of browser window"},
 		flag{"reconnect", "", "Enable reconnection"},
@@ -36,12 +39,15 @@ func main() {
 	}
 
 	mappingHint := map[string]string{
-		"index":      "IndexFile",
-		"tls":        "EnableTLS",
-		"tls-crt":    "TLSCrtFile",
-		"tls-key":    "TLSKeyFile",
-		"random-url": "EnableRandomUrl",
-		"reconnect":  "EnableReconnect",
+		"index":          "IndexFile",
+		"tls":            "EnableTLS",
+		"tls-crt":        "TLSCrtFile",
+		"tls-key":        "TLSKeyFile",
+		"client":         "EnableClientCertificate",
+		"client-ca-file": "ClientCAFile",
+		"client-verify":  "EnableClientCertificateVerification",
+		"random-url":     "EnableRandomUrl",
+		"reconnect":      "EnableReconnect",
 	}
 
 	cliFlags, err := generateFlags(flags, mappingHint)


### PR DESCRIPTION
This pull request adds three new command line options

```
--client, -C                           Enable Client Certificate [$GOTTY_CLIENT]
--client-ca-file "~/.gotty.ca"  Client CA certificate file [$GOTTY_CLIENT_CA_FILE]
--client-verify                       Enable verification of client certificate [$GOTTY_CLIENT_VERIFY]
```

that enable TLS/SSL client certificate authentication for the http server. The change itself is pretty minimal, i added also the relevant documentation and related examples. Let me know what you think, thanks a lot for the project, it rocks!