### PR TITLE
Add 'Server' HTTP header with current GoTTY version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -53,6 +53,8 @@ type Options struct {
 	Preferences     map[string]interface{} `hcl:"preferences"`
 }
 
+var Version = "0.0.10"
+
 var DefaultOptions = Options{
 	Address:         "",
 	Port:            "8080",
@@ -153,6 +155,8 @@ func (app *App) Run() error {
 		log.Printf("Using Basic Authentication")
 		siteHandler = wrapBasicAuth(siteHandler, app.options.Credential)
 	}
+
+	siteHandler = wrapHeaders(siteHandler)
 
 	wsMux := http.NewServeMux()
 	wsMux.Handle("/", siteHandler)
@@ -274,6 +278,13 @@ func wrapLogger(handler http.Handler) http.Handler {
 		rw := &responseWrapper{w, 200}
 		handler.ServeHTTP(rw, r)
 		log.Printf("%s %d %s %s", r.RemoteAddr, rw.status, r.Method, r.URL.Path)
+	})
+}
+
+func wrapHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "GoTTY/"+Version)
+		handler.ServeHTTP(w, r)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	cmd := cli.NewApp()
-	cmd.Version = "0.0.10"
+	cmd.Version = app.Version
 	cmd.Name = "gotty"
 	cmd.Usage = "Share your terminal as a web application"
 	cmd.HideHelp = true


### PR DESCRIPTION
```console
$ curl -I http://gotty.server/
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 407
Content-Type: text/html; charset=utf-8
Last-Modified: Fri, 02 Oct 2015 08:04:28 GMT
Server: GoTTY/0.0.10
Date: Fri, 02 Oct 2015 08:04:28 GMT
```