### PR TITLE
Fix "Quick Sharing on tmux" example:

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To share your current session with others by a shortcut key, you can add a line 
 
 ```
 # Start GoTTY in a new window with C-t
-bind-key C-t new-window "gotty tmux attach -t `tmux display -p '#S'`"
+bind-key C-t new-window "TMUX='' gotty tmux attach -t `tmux display -p '#S'`"
 ```
 
 ## Playing with Docker


### PR DESCRIPTION
The example command of "Quick Sharing on tmux" does not work out of the box, the browser shows only:

`sessions should be nested with care, unset $TMUX to force`

This PR is a proposal to fix that.

Tested with tmux v1.8 and v2.0 on Ubuntu 14.04
