### PR TITLE
Add AssetInfo to AssetFS configuration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -162,7 +162,7 @@ func (app *App) Run() error {
 	customIndexHandler := http.HandlerFunc(app.handleCustomIndex)
 	authTokenHandler := http.HandlerFunc(app.handleAuthToken)
 	staticHandler := http.FileServer(
-		&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "static"},
+		&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, AssetInfo: AssetInfo, Prefix: "static"},
 	)
 
 	var siteMux = http.NewServeMux()


### PR DESCRIPTION
The version of go-bindata-assetfs this project is currently using requires the generated AssetInfo function to be included in the AssetFS configuration. This fixes #90.