### PR TITLE
Also params in ws URL

### DIFF
--- a/resources/gotty.js
+++ b/resources/gotty.js
@@ -1,7 +1,7 @@
 (function() {
     var httpsEnabled = window.location.protocol == "https:";
     var args = window.location.search;
-    var url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws';
+    var url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws' + args;
     var protocols = ["gotty"];
     var autoReconnect = -1;
 


### PR DESCRIPTION
This enables a proxy to authorize the credentials against the params before allowing the websocket connection.

Rather than maintain a fork of gotty with our own auth logic inside, we are more comfortable putting gotty behind an nginx proxy that handles auth. We can already authenticate via this proxy. However, authorization is impossible because the args are only passed in the initial websocket message.

A solution that works for us is to put the args in the `/ws` request query, and to verify in `handleWS` that the args in the init message match the args in the query. Now we can check that the credentials in the request are authorized to run the command with the given args.