### PR TITLE
add -A to aduit client command and save as log file

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -67,6 +67,8 @@ type Options struct {
 	CloseSignal         int                    `hcl:"close_signal"`
 	Preferences         HtermPrefernces        `hcl:"preferences"`
 	RawPreferences      map[string]interface{} `hcl:"preferences"`
+	Aduit               string                 `hcl:"aduit"`
+	EnableAduit         bool                   `hcl:"enable_aduit"`
 }
 
 var Version = "0.0.13"
@@ -91,6 +93,8 @@ var DefaultOptions = Options{
 	Once:                false,
 	CloseSignal:         1, // syscall.SIGHUP
 	Preferences:         HtermPrefernces{},
+	Aduit:               "",
+	EnableAduit:         false,
 }
 
 func New(command []string, options *Options) (*App, error) {
@@ -149,6 +153,14 @@ func (app *App) Run() error {
 
 	if app.options.Once {
 		log.Printf("Once option is provided, accepting only one client")
+	}
+
+	if app.options.EnableAduit {
+		if app.options.Aduit[:1] == "-" || len(app.options.Aduit) < 4 {
+			return errors.New("Aduit is set,but value not set yet")
+		} else {
+			log.Printf("Aduit option is open, Record will write in %s", app.options.Aduit)
+		}
 	}
 
 	path := ""

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		flag{"once", "", "Accept only one client and exit on disconnection"},
 		flag{"permit-arguments", "", "Permit clients to send command line arguments in URL (e.g. http://example.com:8080/?arg=AAA&arg=BBB)"},
 		flag{"close-signal", "", "Signal sent to the command process when gotty close it (default: SIGHUP)"},
+		flag{"aduit", "A", "Add logs to record all operations"},
 	}
 
 	mappingHint := map[string]string{
@@ -87,6 +88,10 @@ func main() {
 		}
 		if c.IsSet("tls-ca-crt") {
 			options.EnableTLSClientAuth = true
+		}
+
+		if c.IsSet("aduit") {
+			options.EnableAduit = true
 		}
 
 		if err := app.CheckConfig(&options); err != nil {


### PR DESCRIPTION
Aduit client Command and result as log
1.add flag -A *.log
2.looks like this:

- 2016/07/15 15:46:59 cst@debian:Receive# w
- 2016/07/15 15:46:59 cst@debian:Send# 
- 2016/07/15 15:46:59 cst@debian:Send#  15:46:59 up 11 days,  4:18,  7 users,  load average: 1.52, 1.34, 1.29
- 2016/07/15 15:46:59 cst@debian:Send# 
- 2016/07/15 15:46:59 cst@debian:Send# USER     TTY      FROM             LOGIN@   IDLE   JCPU   PCPU WHAT
- 2016/07/15 15:46:59 cst@debian:Send# 
- 2016/07/15 15:46:59 cst@debian:Send# root     :0       :0               04Jul16 ?xdm?  44:18m  0.60s gdm-session-worker [pam/gdm-password]
- 2016/07/15 15:46:59 cst@debian:Send# root     pts/7    :0               04Jul16  3days  0.24s  0.00s tmux