### PR TITLE
Path support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -48,6 +48,7 @@ type App struct {
 type Options struct {
 	Address             string                 `hcl:"address"`
 	Port                string                 `hcl:"port"`
+	Path                string                 `hcl:"path"`
 	PermitWrite         bool                   `hcl:"permit_write"`
 	EnableBasicAuth     bool                   `hcl:"enable_basic_auth"`
 	Credential          string                 `hcl:"credential"`
@@ -74,6 +75,7 @@ var Version = "0.0.13"
 var DefaultOptions = Options{
 	Address:             "",
 	Port:                "8080",
+	Path:		     "",
 	PermitWrite:         false,
 	EnableBasicAuth:     false,
 	Credential:          "",
@@ -154,6 +156,8 @@ func (app *App) Run() error {
 	path := ""
 	if app.options.EnableRandomUrl {
 		path += "/" + generateRandomString(app.options.RandomUrlLength)
+	} else if app.options.Path != "" {
+		path += "/" + app.options.Path
 	}
 
 	endpoint := net.JoinHostPort(app.options.Address, app.options.Port)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	flags := []flag{
 		flag{"address", "a", "IP address to listen"},
 		flag{"port", "p", "Port number to listen"},
+		flag{"path", "", "Path to listen"},
 		flag{"permit-write", "w", "Permit clients to write to the TTY (BE CAREFUL)"},
 		flag{"credential", "c", "Credential for Basic Authentication (ex: user:pass, default disabled)"},
 		flag{"random-url", "r", "Add a random string to the URL"},


### PR DESCRIPTION
Fixes #92 

Usage:
`gotty --path watchtop top` would output top to www.example.com/watchtop using the following nginx config: 
```
location /watchtop {
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;                              
                proxy_set_header Host $http_host;
                proxy_set_header Upgrade $http_upgrade;                                                   
                proxy_set_header Connection "upgrade";
                proxy_redirect off;
                proxy_pass http://localhost:8080;
}
```