### PR TITLE
Add support for listening on random port, fixes #97

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 
 ```
 --address, -a                                                IP address to listen [$GOTTY_ADDRESS]
---port, -p "8080"                                            Port number to listen [$GOTTY_PORT]
+--port, -p "8080"                                            Port number to listen (use "0" for random port) [$GOTTY_PORT]
 --permit-write, -w                                           Permit clients to write to the TTY (BE CAREFUL) [$GOTTY_PERMIT_WRITE]
 --credential, -c                                             Credential for Basic Authentication (ex: user:pass, default disabled) [$GOTTY_CREDENTIAL]
 --random-url, -r                                             Add a random string to the URL [$GOTTY_RANDOM_URL]

--- a/app/app.go
+++ b/app/app.go
@@ -160,6 +160,15 @@ func (app *App) Run() error {
 		path += "/" + generateRandomString(app.options.RandomUrlLength)
 	}
 
+	if app.options.Port == "0" {
+		port, err := allocatePort()
+		if err != nil {
+			return errors.New("Failed to allocate random port: " + err.Error())
+		}
+		app.options.Port = strconv.Itoa(port)
+		log.Printf("Allocated random port: %s", app.options.Port)
+	}
+
 	endpoint := net.JoinHostPort(app.options.Address, app.options.Port)
 
 	wsHandler := http.HandlerFunc(app.handleWS)
@@ -473,4 +482,13 @@ func ExpandHomeDir(path string) string {
 	} else {
 		return path
 	}
+}
+
+func allocatePort() (int, error) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port, nil
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	cmd.HideHelp = true
 
 	flags := []flag{
-		flag{"address", "a", "IP address to listen"},
+		flag{"address", "a", "IP address to listen (use \"0\" for random port)"},
 		flag{"port", "p", "Port number to listen"},
 		flag{"permit-write", "w", "Permit clients to write to the TTY (BE CAREFUL)"},
 		flag{"credential", "c", "Credential for Basic Authentication (ex: user:pass, default disabled)"},


### PR DESCRIPTION
The idea is to listen on port `0` to let the os pick a free port for us, then use it!
