### PR TITLE
Add an option to disable client window resizes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -70,6 +70,8 @@ type Options struct {
 	CloseSignal         int                    `hcl:"close_signal"`
 	Preferences         HtermPrefernces        `hcl:"preferences"`
 	RawPreferences      map[string]interface{} `hcl:"preferences"`
+	Width               int                    `hcl:"width"`
+	Height              int                    `hcl:"height"`
 }
 
 var Version = "0.0.13"
@@ -95,6 +97,8 @@ var DefaultOptions = Options{
 	Once:                false,
 	CloseSignal:         1, // syscall.SIGHUP
 	Preferences:         HtermPrefernces{},
+	Width:               0,
+	Height:              0,
 }
 
 func New(command []string, options *Options) (*App, error) {

--- a/app/client_context.go
+++ b/app/client_context.go
@@ -197,14 +197,24 @@ func (context *clientContext) processReceive() {
 				return
 			}
 
+			rows := uint16(context.app.options.Height)
+			if rows == 0 {
+				rows = uint16(args.Rows)
+			}
+
+			columns := uint16(context.app.options.Width)
+			if columns == 0 {
+				columns = uint16(args.Columns)
+			}
+
 			window := struct {
 				row uint16
 				col uint16
 				x   uint16
 				y   uint16
 			}{
-				uint16(args.Rows),
-				uint16(args.Columns),
+				rows,
+				columns,
 				0,
 				0,
 			}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 		flag{"once", "", "Accept only one client and exit on disconnection"},
 		flag{"permit-arguments", "", "Permit clients to send command line arguments in URL (e.g. http://example.com:8080/?arg=AAA&arg=BBB)"},
 		flag{"close-signal", "", "Signal sent to the command process when gotty close it (default: SIGHUP)"},
+		flag{"width", "", "Static width of the screen, 0(default) means dynamically resize"},
+		flag{"height", "", "Static height of the screen, 0(default) means dynamically resize"},
 	}
 
 	mappingHint := map[string]string{


### PR DESCRIPTION
This goes great with tmux when you are sharing your terminal for
presentations and you don't want to give viewers the ability to resize
your terminal
