### PR TITLE
Add reuseport

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 		flag{"once", "", "Accept only one client and exit on disconnection"},
 		flag{"permit-arguments", "", "Permit clients to send command line arguments in URL (e.g. http://example.com:8080/?arg=AAA&arg=BBB)"},
 		flag{"close-signal", "", "Signal sent to the command process when gotty close it (default: SIGHUP)"},
+		flag{"reuse-port", "", "Reuse same TCP socket with another process"},
 	}
 
 	mappingHint := map[string]string{

--- a/vendor/github.com/kavu/go_reuseport/.gitignore
+++ b/vendor/github.com/kavu/go_reuseport/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/kavu/go_reuseport/.travis.yml
+++ b/vendor/github.com/kavu/go_reuseport/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+group: edge
+
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - tip
+
+os:
+  - linux
+  - osx
+
+before_install:
+  - uname -a
+
+script:
+  - go test -v ./...
+  - go test -v -benchmem -benchtime=5s -bench=.
+
+matrix:
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/kavu/go_reuseport/LICENSE
+++ b/vendor/github.com/kavu/go_reuseport/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Max Riveiro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/kavu/go_reuseport/README.md
+++ b/vendor/github.com/kavu/go_reuseport/README.md
@@ -1,0 +1,49 @@
+# GO_REUSEPORT
+
+[![Build Status](https://travis-ci.org/kavu/go_reuseport.png?branch=master)](https://travis-ci.org/kavu/go_reuseport)
+[![GoDoc](https://godoc.org/github.com/kavu/go_reuseport?status.png)](https://godoc.org/github.com/kavu/go_reuseport)
+
+**GO_REUSEPORT** is a little expirement to create a `net.Listener` that supports [SO_REUSEPORT](http://lwn.net/Articles/542629/) socket option.
+
+For now, Darwin and Linux (from 3.9) systems are supported. I'll be pleased if you'll test other systems and tell me the results.
+ documentation on [godoc.org](http://godoc.org/github.com/kavu/go_reuseport "go_reuseport documentation").
+
+## Example ##
+
+```go
+package main
+
+import (
+  "fmt"
+  "html"
+  "net/http"
+  "os"
+  "runtime"
+  "github.com/kavu/go_reuseport"
+)
+
+func main() {
+  runtime.GOMAXPROCS(runtime.NumCPU())
+
+  listener, err := reuseport.NewReusablePortListener("tcp4", "localhost:8881")
+  if err != nil {
+    panic(err)
+  }
+  defer listener.Close()
+
+  server := &http.Server{}
+  http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+    fmt.Println(os.Getgid())
+    fmt.Fprintf(w, "Hello, %q\n", html.EscapeString(r.URL.Path))
+  })
+
+  panic(server.Serve(listener))
+}
+```
+
+Now you can run several instances of this tiny server without `Address already in use` errors.
+
+## Thanks
+
+Inspired by [Artur Siekielski](https://github.com/aartur) [post](http://freeprogrammersblog.vhex.net/post/linux-39-introdued-new-way-of-writing-socket-servers/2) about `SO_REUSEPORT`.
+

--- a/vendor/github.com/kavu/go_reuseport/reuseport.go
+++ b/vendor/github.com/kavu/go_reuseport/reuseport.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2013 Max Riveiro
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package reuseport provides a function that returns a net.Listener powered by a net.FileListener with a SO_REUSEPORT option set to the socket.
+package reuseport
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+const (
+	tcp4                  = 52 // "4"
+	tcp6                  = 54 // "6"
+	unsupportedProtoError = "Only tcp, tcp4 and tcp6 are supported"
+	filePrefix            = "port."
+)
+
+var listenerBacklog = maxListenerBacklog()
+
+// getSockaddr parses protocol and address and returns implementor syscall.Sockaddr: syscall.SockaddrInet4 or syscall.SockaddrInet6.
+func getSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err error) {
+	var (
+		addr4 [4]byte
+		addr6 [16]byte
+		ip    *net.TCPAddr
+	)
+
+	ip, err = net.ResolveTCPAddr(proto, addr)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	switch determineProto(proto, ip) {
+	default:
+		return nil, -1, errors.New(unsupportedProtoError)
+	case tcp4:
+		if ip.IP != nil {
+			copy(addr4[:], ip.IP[12:16]) // copy last 4 bytes of slice to array
+		}
+		return &syscall.SockaddrInet4{Port: ip.Port, Addr: addr4}, syscall.AF_INET, nil
+	case tcp6:
+		if ip.IP != nil {
+			copy(addr6[:], ip.IP) // copy all bytes of slice to array
+		}
+		return &syscall.SockaddrInet6{Port: ip.Port, Addr: addr6}, syscall.AF_INET6, nil
+	}
+}
+
+// determineProto determines the protocol for syscall.Sockaddr (tcp4 or tcp6).
+func determineProto(proto string, ip *net.TCPAddr) byte {
+	// If the protocol is set to "tcp", we determine the actual protocol
+	// version from the size of the IP address. Otherwise, we use the
+	// protcol given to us by the caller.
+	if proto == "tcp" {
+		if ip.IP.To4() != nil {
+			return tcp4
+		}
+		return tcp6
+	}
+	return proto[len(proto)-1]
+}
+
+// NewReusablePortListener returns net.FileListener that created from a file discriptor for a socket with SO_REUSEPORT option.
+func NewReusablePortListener(proto, addr string) (l net.Listener, err error) {
+	var (
+		soType, fd int
+		file       *os.File
+		sockaddr   syscall.Sockaddr
+	)
+
+	if sockaddr, soType, err = getSockaddr(proto, addr); err != nil {
+		return nil, err
+	}
+
+	if fd, err = syscall.Socket(soType, syscall.SOCK_STREAM, syscall.IPPROTO_TCP); err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			syscall.Close(fd)
+		}
+	}()
+
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+		return nil, err
+	}
+
+	if err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, reusePort, 1); err != nil {
+		return nil, err
+	}
+
+	if err = syscall.Bind(fd, sockaddr); err != nil {
+		return nil, err
+	}
+
+	// Set backlog size to the maximum
+	if err = syscall.Listen(fd, listenerBacklog); err != nil {
+		return nil, err
+	}
+
+	// File Name get be nil
+	file = os.NewFile(uintptr(fd), filePrefix+strconv.Itoa(os.Getpid()))
+	if l, err = net.FileListener(file); err != nil {
+		return nil, err
+	}
+
+	if err = file.Close(); err != nil {
+		return nil, err
+	}
+
+	return l, err
+}

--- a/vendor/github.com/kavu/go_reuseport/reuseport_bsd.go
+++ b/vendor/github.com/kavu/go_reuseport/reuseport_bsd.go
@@ -1,0 +1,35 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package reuseport
+
+import (
+	"runtime"
+	"syscall"
+)
+
+var reusePort = syscall.SO_REUSEPORT
+
+func maxListenerBacklog() int {
+	var (
+		n   uint32
+		err error
+	)
+	switch runtime.GOOS {
+	case "darwin", "freebsd":
+		n, err = syscall.SysctlUint32("kern.ipc.somaxconn")
+	case "netbsd":
+		// NOTE: NetBSD has no somaxconn-like kernel state so far
+	case "openbsd":
+		n, err = syscall.SysctlUint32("kern.somaxconn")
+	}
+	if n == 0 || err != nil {
+		return syscall.SOMAXCONN
+	}
+	// FreeBSD stores the backlog in a uint16, as does Linux.
+	// Assume the other BSDs do too. Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return int(n)
+}

--- a/vendor/github.com/kavu/go_reuseport/reuseport_linux.go
+++ b/vendor/github.com/kavu/go_reuseport/reuseport_linux.go
@@ -1,0 +1,39 @@
+package reuseport
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+var reusePort = 0x0F
+
+func maxListenerBacklog() int {
+	fd, err := os.Open("/proc/sys/net/core/somaxconn")
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	defer fd.Close()
+	rd := bufio.NewReader(fd)
+	line, err := rd.ReadString('\n')
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	f := strings.Fields(line)
+	if len(f) < 1 {
+		return syscall.SOMAXCONN
+	}
+	n, err := strconv.Atoi(f[0])
+	if err != nil || n == 0 {
+		return syscall.SOMAXCONN
+	}
+	// Linux stores the backlog in a uint16.
+	// Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return n
+}

--- a/vendor/github.com/kavu/go_reuseport/reuseport_test.go
+++ b/vendor/github.com/kavu/go_reuseport/reuseport_test.go
@@ -1,0 +1,159 @@
+package reuseport
+
+import (
+	"fmt"
+	"html"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	serverOneResponse   = "1"
+	serverTwoResponse   = "2"
+	serverThreeResponse = "3"
+)
+
+var (
+	serverOne   = NewServer(serverOneResponse)
+	serverTwo   = NewServer(serverTwoResponse)
+	serverThree = NewServer(serverThreeResponse)
+)
+
+func NewServer(resp string) *httptest.Server {
+	return httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, resp)
+	}))
+}
+
+func TestNewReusablePortListener(t *testing.T) {
+	listenerOne, err := NewReusablePortListener("tcp4", "localhost:10081")
+	if err != nil {
+		panic(err)
+	}
+	defer listenerOne.Close()
+
+	listenerTwo, err := NewReusablePortListener("tcp", "127.0.0.1:10081")
+	if err != nil {
+		panic(err)
+	}
+	defer listenerTwo.Close()
+
+	// listenerThree, err := NewReusablePortListener("tcp6", "[::1]:10081")
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// defer listenerThree.Close()
+
+	serverOne.Listener = listenerOne
+	serverTwo.Listener = listenerTwo
+	// serverThree.Listener = listenerThree
+
+	serverOne.Start()
+	serverTwo.Start()
+
+	// Server One — First Response
+	resp1, err := http.Get(serverOne.URL)
+	if err != nil {
+		panic(err)
+	}
+	body1, err := ioutil.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	if string(body1) != serverOneResponse && string(body1) != serverTwoResponse {
+		t.Errorf("Expected %#v or %#v, got %#v.", serverOneResponse, serverTwoResponse, string(body1))
+	}
+
+	// Server Two — First Response
+	resp2, err := http.Get(serverTwo.URL)
+	if err != nil {
+		panic(err)
+	}
+	body2, err := ioutil.ReadAll(resp2.Body)
+	resp1.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	if string(body2) != serverOneResponse && string(body2) != serverTwoResponse {
+		t.Errorf("Expected %#v or %#v, got %#v.", serverOneResponse, serverTwoResponse, string(body2))
+	}
+
+	serverTwo.Close()
+
+	// Server One — Second Response
+	resp3, err := http.Get(serverOne.URL)
+	if err != nil {
+		panic(err)
+	}
+	body3, err := ioutil.ReadAll(resp3.Body)
+	resp1.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	if string(body3) != serverOneResponse {
+		t.Errorf("Expected %#v, got %#v.", serverOneResponse, string(body3))
+	}
+
+	serverThree.Start()
+
+	// Server Three — First Response
+	resp4, err := http.Get(serverThree.URL)
+	if err != nil {
+		panic(err)
+	}
+	body4, err := ioutil.ReadAll(resp4.Body)
+	resp1.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	if string(body4) != serverThreeResponse {
+		t.Errorf("Expected %#v, got %#v.", serverThreeResponse, string(body4))
+	}
+
+	serverThree.Close()
+
+	// Server One — Third Response
+	resp5, err := http.Get(serverOne.URL)
+	if err != nil {
+		panic(err)
+	}
+	body5, err := ioutil.ReadAll(resp5.Body)
+	resp1.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	if string(body5) != serverOneResponse {
+		t.Errorf("Expected %#v, got %#v.", serverOneResponse, string(body5))
+	}
+
+	serverOne.Close()
+}
+
+func BenchmarkNewReusablePortListener(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		listener, err := NewReusablePortListener("tcp4", "localhost:10081")
+		if err != nil {
+			b.Error(err)
+		}
+		listener.Close()
+	}
+}
+
+func ExampleNewReusablePortListener(b *testing.B) {
+	listener, err := NewReusablePortListener("tcp4", ":8881")
+	if err != nil {
+		panic(err)
+	}
+	defer listener.Close()
+
+	server := &http.Server{}
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %q\n", html.EscapeString(r.URL.Path))
+		listener.Close()
+	})
+
+	panic(server.Serve(listener))
+}


### PR DESCRIPTION
--reuse-port using SO_REUSEPORT socket flag to share same TCP port with other processes created under the same system user.
It can be used to provide racefree mechanism of binding TCP port when some front-end is open socket for gotty, start gotty process and than close own socket.
