### PR TITLE
Support deploying bash in Cloud Foundry via GoTTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ If you have a Go language environment, you can install GoTTY with the `go get` c
 $ go get github.com/yudai/gotty
 ```
 
+## Cloud Foundry Deployment
+
+```sh
+$ cf push --random-route
+```
+
 # Usage
 
 ```

--- a/app/app.go
+++ b/app/app.go
@@ -160,7 +160,7 @@ func (app *App) Run() error {
 		path += "/" + generateRandomString(app.options.RandomUrlLength)
 	}
 
-	endpoint := net.JoinHostPort(app.options.Address, app.options.Port)
+	endpoint := net.JoinHostPort(app.options.Address, os.Getenv("PORT"))
 
 	wsHandler := http.HandlerFunc(app.handleWS)
 	customIndexHandler := http.HandlerFunc(app.handleCustomIndex)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: gotty
+  command: gotty -w bash
+  memory: 128m
+  env:
+    GOPACKAGENAME: main
+    TERM: "xterm-256color"


### PR DESCRIPTION
Added a manifest file that is used by default by Cloud Foundry's cli
`cf push` command. This manifest causes GoTTY to launch bash and allow
it to accept keystrokes. We do not use GoTTY's -c parameter to force use
of credentials, because that requires that the user update the manifest
file before `cf push`, and also have the utilities to generate secure
password on her machine. We use the alternative method to obscure the
access to this app by recommending (in README) to use the --random-route
option.

Updated code to listen on environment variable PORT. This overrides
logic that purportedly supports choosing a different port via environment
variable GOTTY_PORT. But since that doesn't really work (see issue #122)
it's okay for us to hack this to support Cloud Foundry.