### PR TITLE
Added path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 ```
 --address, -a                                                IP address to listen [$GOTTY_ADDRESS]
 --port, -p "8080"                                            Port number to listen [$GOTTY_PORT]
+--path, -m ""                                                Base path
 --permit-write, -w                                           Permit clients to write to the TTY (BE CAREFUL) [$GOTTY_PERMIT_WRITE]
 --credential, -c                                             Credential for Basic Authentication (ex: user:pass, default disabled) [$GOTTY_CREDENTIAL]
 --random-url, -r                                             Add a random string to the URL [$GOTTY_RANDOM_URL]

--- a/app/app.go
+++ b/app/app.go
@@ -55,6 +55,7 @@ type App struct {
 type Options struct {
 	Address             string                 `hcl:"address"`
 	Port                string                 `hcl:"port"`
+	Path								string								 `hcl:"path"`
 	PermitWrite         bool                   `hcl:"permit_write"`
 	EnableBasicAuth     bool                   `hcl:"enable_basic_auth"`
 	Credential          string                 `hcl:"credential"`
@@ -85,6 +86,7 @@ var Version = "0.0.13"
 var DefaultOptions = Options{
 	Address:             "",
 	Port:                "8080",
+	Path:								 "",
 	PermitWrite:         false,
 	EnableBasicAuth:     false,
 	Credential:          "",
@@ -168,7 +170,7 @@ func (app *App) Run() error {
 		log.Printf("Once option is provided, accepting only one client")
 	}
 
-	path := ""
+	path := app.options.Path
 	if app.options.EnableRandomUrl {
 		path += "/" + generateRandomString(app.options.RandomUrlLength)
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	flags := []flag{
 		flag{"address", "a", "IP address to listen"},
 		flag{"port", "p", "Port number to listen"},
+		flag{"path", "m", "Base path"},
 		flag{"permit-write", "w", "Permit clients to write to the TTY (BE CAREFUL)"},
 		flag{"credential", "c", "Credential for Basic Authentication (ex: user:pass, default disabled)"},
 		flag{"random-url", "r", "Add a random string to the URL"},


### PR DESCRIPTION
I wanted to use --random-url, but need to generate the random string myself and pass it to gotty.