### PR TITLE
removed comma in sample config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ enable_tls = true
 // hterm preferences
 // Smaller font and a little bit bluer background color
 preferences {
-    font_size = 5,
+    font_size = 5
     background_color = "rgb(16, 16, 32)"
 }
 ```


### PR DESCRIPTION
The quick example config file has a comma after font_size configuration line which is incorrect.