### PR TITLE
Feature: Docker containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.8
+MAINTAINER Rafael Bodill <justrafi@gmail.com>
+
+ENV TERM=xterm-256color
+ENV GOTTY_PORT=8080
+ENV GOTTY_ADDRESS=127.0.0.1
+EXPOSE $GOTTY_PORT
+
+RUN [ -d /go/src/github.com/yudai/gotty ] \
+  || mkdir -p /go/src/github.com/yudai/gotty
+
+WORKDIR /go/src/github.com/yudai/gotty
+
+ENTRYPOINT ["/go/bin/gotty", "--permit-write"]
+CMD ["bash"]
+
+COPY . /go/src/github.com/yudai/gotty
+RUN go install -v github.com/yudai/gotty

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ If you have a Go language environment, you can install GoTTY with the `go get` c
 $ go get github.com/yudai/gotty
 ```
 
+## Docker Installation
+
+1. Clone repository: `git clone git@github.com:yudai/gotty.git`
+1. Jump into it: `cd gotty`
+1. Either use `docker-compose up` or manually with docker itself:
+
+```sh
+$ docker build -t gotty .
+$ docker run --rm --publish 8080:8080 gotty
+```
+
+The default command runs the bash shell in the container.
+You can also run one-off commands, e.g.:
+
+```sh
+$ docker run --rm --publish 8080:8080 gotty --once top -o %CPU
+```
+
+Finally, open your browser on http://localhost:8080
+
 # Usage
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  gotty:
+    build: .
+    image: gotty
+    container_name: gotty-instance
+    ports:
+      - 8080:8080
+    volumes:
+      - "${PWD}:/go/src/github.com/yudai/gotty"
+    environment:
+      TERM: xterm-256color
+      GOTTY_PORT: 8080
+      GOTTY_ADDRESS: 127.0.0.1


### PR DESCRIPTION
- Add initial Dockerfile with default environment options
- Add initial docker-compose configuration
- Add docker installation guide in README.md

## Usage
- Either use `docker-compose`:
```sh
docker-compose up
```
- Or `docker` manually:
```sh
$ docker build -t gotty .
$ docker run --rm --publish 8080:8080 gotty
```

You can run one-off commands too, e.g.:
```sh
docker run --rm --publish 8080:8080 gotty --once top -o %CPU
```