### PR TITLE
Feature - allow passing environment variables, user-name and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --max-connection "0"                                         Set the maximum number of simultaneous connections (0 to disable)
 --once                                                       Accept only one client and exit on disconnection [$GOTTY_ONCE]
 --permit-arguments                                           Permit clients to send command line arguments in URL (e.g. http://example.com:8080/?arg=AAA&arg=BBB) [$GOTTY_PERMIT_ARGUMENTS]
+--permit-environment                                         Permit clients to add (or replace) environment variables in URL (e.g. http://example.com:8080/?env=GOTTY=running&env=TMUXsession=name)
+--enable-auth-args                                           Reuse the http basic-auth user-name and password to replace all '%u' and '%p' in arguments
 --close-signal "1"                                           Signal sent to the command process when gotty close it (default: SIGHUP) [$GOTTY_CLOSE_SIGNAL]
 --config "~/.gotty"                                          Config file path [$GOTTY_CONFIG]
 --version, -v                                                print the version

--- a/main.go
+++ b/main.go
@@ -40,6 +40,8 @@ func main() {
 		flag{"close-signal", "", "Signal sent to the command process when gotty close it (default: SIGHUP)"},
 		flag{"width", "", "Static width of the screen, 0(default) means dynamically resize"},
 		flag{"height", "", "Static height of the screen, 0(default) means dynamically resize"},
+		flag{"permit-environment", "", "Permit clients to send environment variables in URL (e.g. http://example.com:8080/?env=ZZZ&env=YYY)"},
+		flag{"enable-auth-args", "", "Use in combination with %u and %p as arguments that will be replaced with the username and password used with HTTP auth"},
 	}
 
 	mappingHint := map[string]string{


### PR DESCRIPTION
Changes made to satisfy a personal use-case:

Running GoTTY with "-c user:pass **login -p %u**" (+ config file for TLS), and accessing GoTTY via a url similar to https://example.com/?env=GOTTY=present&TMUXname=asession

This, in combination with some edits in .bashrc allows me to login to a TMUX session named on the URL.
Reasoning about login: extra layer of security - don't allow brute force of real password via GoTTY / don't put real password in config, but also skip retyping the user-name.

Note: feature added to 1.0 release as had started looking at code before it was branched off, started looking at how to implement this with the current master branch, but my build environment is not working for this branch at the moment (go objecting to use of "*http.Server ServeTLS(...)" for no good reason I can see)