### PR TITLE
add flags to export cookies and headers to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --once                                                       Accept only one client and exit on disconnection [$GOTTY_ONCE]
 --permit-arguments                                           Permit clients to send command line arguments in URL (e.g. http://example.com:8080/?arg=AAA&arg=BBB) [$GOTTY_PERMIT_ARGUMENTS]
 --close-signal "1"                                           Signal sent to the command process when gotty close it (default: SIGHUP) [$GOTTY_CLOSE_SIGNAL]
+--env-prefix value                                           Prefix to export cookies and headers from http request to env (default: "WEB_REQ_") [$GOTTY_ENV_PREFIX]
+--env-export-cookies                                         Enable cookies export to env [$GOTTY_ENV_EXPORT_COOKIES]
+--env-export-headers                                         Enable headers export to env [$GOTTY_ENV_EXPORT_HEADERS]
 --config "~/.gotty"                                          Config file path [$GOTTY_CONFIG]
 --version, -v                                                print the version
 ```

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func Test_normalizeEnvName(t *testing.T) {
+	input := "Test-Camel-Dash-Name"
+	expected := "TEST_CAMEL_DASH_NAME"
+
+	output := normalizeEnvName(input)
+
+	if output != expected {
+		t.Errorf("Normalization failed. OUTPUT: %s, EXPECTED: %s", output, expected)
+		return
+	}
+}
+
+func Test_exportEnv_coockies(t *testing.T) {
+	enableExportCookies := true
+	enableExportHeaders := false
+	envPrefix := "Web_Req_"
+	req := httptest.NewRequest("GET", "localhost:20081", nil)
+
+	req.AddCookie(&http.Cookie{
+		Name:  "session",
+		Value: "session_id",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "x-token",
+		Value: "token_value",
+	})
+
+	expected := []string{"WEB_PREFIX=WEB_REQ_", "WEB_REQ_COOKIE_SESSION=session_id", "WEB_REQ_COOKIE_X_TOKEN=token_value"}
+	output := exportEnv(enableExportCookies, enableExportHeaders, envPrefix, req)
+
+	if !reflect.DeepEqual(expected, output) {
+		t.Errorf("Cookies export failed. OUTPUT: %v, EXPECTED: %v", output, expected)
+		return
+	}
+}
+
+func Test_exportEnv_headers(t *testing.T) {
+	enableExportCookies := false
+	enableExportHeaders := true
+	envPrefix := "web_req_"
+	req := httptest.NewRequest("GET", "localhost:20081", nil)
+
+	req.Header.Add("Container-id", "ad313e67d06a")
+	req.Header.Add("Role", "test-role")
+
+	expected := []string{"WEB_PREFIX=WEB_REQ_", "WEB_REQ_HEADER_CONTAINER_ID=ad313e67d06a", "WEB_REQ_HEADER_ROLE=test-role"}
+	output := exportEnv(enableExportCookies, enableExportHeaders, envPrefix, req)
+
+	if len(expected) != len(output) {
+		t.Errorf("Headers Len failed. OUTPUT: %v, EXPECTED: %v", output, expected)
+		return
+	}
+
+	for _, e := range expected {
+		if !stringInSlice(e, output) {
+			t.Errorf("Headers export failed. v: %s, OUTPUT: %v, EXPECTED: %v", e, output, expected)
+			return
+		}
+	}
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -40,16 +40,22 @@ func main() {
 		flag{"close-signal", "", "Signal sent to the command process when gotty close it (default: SIGHUP)"},
 		flag{"width", "", "Static width of the screen, 0(default) means dynamically resize"},
 		flag{"height", "", "Static height of the screen, 0(default) means dynamically resize"},
+		flag{"env-prefix", "", "Prefix to export cookies and headers from http request to env"},
+		flag{"env-export-cookies", "", "Enable cookies export to env"},
+		flag{"env-export-headers", "", "Enable headers export to env"},
 	}
 
 	mappingHint := map[string]string{
-		"index":      "IndexFile",
-		"tls":        "EnableTLS",
-		"tls-crt":    "TLSCrtFile",
-		"tls-key":    "TLSKeyFile",
-		"tls-ca-crt": "TLSCACrtFile",
-		"random-url": "EnableRandomUrl",
-		"reconnect":  "EnableReconnect",
+		"index":              "IndexFile",
+		"tls":                "EnableTLS",
+		"tls-crt":            "TLSCrtFile",
+		"tls-key":            "TLSKeyFile",
+		"tls-ca-crt":         "TLSCACrtFile",
+		"random-url":         "EnableRandomUrl",
+		"reconnect":          "EnableReconnect",
+		"env-prefix":         "EnvPrefix",
+		"env-export-cookies": "EnableEnvExportCookies",
+		"env-export-headers": "EnableEnvExportHeaders",
 	}
 
 	cliFlags, err := generateFlags(flags, mappingHint)


### PR DESCRIPTION
Exporting headers/cookies as environment variables was implemented.

**Use-case:**
Pass "sessoin-id" to command which will check permissions/auth by external service
