### PR TITLE
Simple history load support for new connections

### DIFF
--- a/server/slave.go
+++ b/server/slave.go
@@ -4,6 +4,8 @@ import (
 	"github.com/yudai/gotty/webtty"
 )
 
+// WithHistory represents TTY that has readable history.
+// Read webtty.WithHistory documentation for more information.
 type WithHistory interface {
 	webtty.WithHistory
 }

--- a/server/slave.go
+++ b/server/slave.go
@@ -4,6 +4,10 @@ import (
 	"github.com/yudai/gotty/webtty"
 )
 
+type WithHistory interface {
+	webtty.WithHistory
+}
+
 // Slave is webtty.Slave with some additional methods.
 type Slave interface {
 	webtty.Slave

--- a/webtty/slave.go
+++ b/webtty/slave.go
@@ -4,6 +4,10 @@ import (
 	"io"
 )
 
+type WithHistory interface {
+	HistoryReader() io.Reader
+}
+
 // Slave represents a PTY slave, typically it's a local command.
 type Slave interface {
 	io.ReadWriter

--- a/webtty/slave.go
+++ b/webtty/slave.go
@@ -4,6 +4,19 @@ import (
 	"io"
 )
 
+// WithHistory represents TTY that has readable history.
+// If Slave implements WithHistory interface, WebTTY calls HistoryReader() for each Slave instance on connection
+// establishment will copy data from HistoryReader to Master til EOF.
+// History will be sent to Master before any other data written to the slave from the moment of connection.
+//
+// Typical flow of new WebTTY connection:
+//        [WebSocket connection establishment]
+//                          V
+//   [terminal initialization messages from server]
+//                          V
+//             [history data from server]
+//                          V
+//   [client<->server bidirectional data streaming]
 type WithHistory interface {
 	HistoryReader() io.Reader
 }

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"github.com/pkg/errors"
 	"io"
-	"log"
 	"sync"
 )
 

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"sync"
-
 	"github.com/pkg/errors"
+	"io"
+	"log"
+	"sync"
 )
 
 // WebTTY bridges a PTY slave and its PTY master.
@@ -62,6 +63,11 @@ func (wt *WebTTY) Run(ctx context.Context) error {
 	err := wt.sendInitializeMessage()
 	if err != nil {
 		return errors.Wrapf(err, "failed to send initializing message")
+	}
+
+	err = wt.sendSlaveHistory()
+	if err != nil {
+		return errors.Wrapf(err, "failed to send terminal history message")
 	}
 
 	errs := make(chan error, 2)
@@ -131,6 +137,36 @@ func (wt *WebTTY) sendInitializeMessage() error {
 	}
 
 	return nil
+}
+
+func (wt *WebTTY) sendSlaveHistory() error {
+	slave, hasHistory := wt.slave.(WithHistory)
+	if !hasHistory {
+		return nil
+	}
+
+	history := slave.HistoryReader()
+	if history == nil {
+		return nil
+	}
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := history.Read(buf)
+		if err == io.EOF {
+			return nil
+		}
+
+		if err != nil {
+			return errors.Wrap(err, "failed to read history log")
+		}
+
+		safeMessage := base64.StdEncoding.EncodeToString(buf[:n])
+		err = wt.masterWrite(append([]byte{Output}, []byte(safeMessage)...))
+		if err != nil {
+			return errors.Wrap(err, "failed to send log to master")
+		}
+	}
 }
 
 func (wt *WebTTY) handleSlaveReadEvent(data []byte) error {


### PR DESCRIPTION
Adds new interface support and new connection initialization step for loading history into already-active TTY session.

This function is actual for situations, when new GoTTY client connection is attached to an existing terminal/process.