### PR TITLE
Stop hterm spamming with errors to console after deactivate()

### DIFF
--- a/js/src/hterm.ts
+++ b/js/src/hterm.ts
@@ -75,9 +75,9 @@ export class Hterm {
     };
 
     deactivate(): void {
-        this.io.onVTKeystroke = null;
-        this.io.sendString = null
-        this.io.onTerminalResize = null;
+        this.io.onVTKeystroke    = function(){};
+        this.io.sendString       = function(){};
+        this.io.onTerminalResize = function(){};
         this.term.uninstallKeyboard();
     }
 


### PR DESCRIPTION
If you have gotty js client installation on a separate page (not native one, provided by gotty server itself), you might have reason to keep console open even after websocket connection close.
When you use hterm - nulling on<Event> handlers of IO causes error messages spam in console log.

Better to stub handlers with empty functions.