### PR TITLE
options: add flags for cmd, argv

### DIFF
--- a/.gotty
+++ b/.gotty
@@ -1,3 +1,9 @@
+// [string] Command to run
+// command = "top"
+
+// [string] Command args
+// args = "-o %CPU"
+
 // [string] Address to listen, all addresses will be used when empty
 // address = ""
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 ## Options
 
 ```
+--command value, -x value     Command to run [$GOTTY_COMMAND]
+--args value, -g value        Command arguments [$GOTTY_ARGS]
 --address value, -a value     IP address to listen (default: "0.0.0.0") [$GOTTY_ADDRESS]
 --port value, -p value        Port number to liten (default: "8080") [$GOTTY_PORT]
 --permit-write, -w            Permit clients to write to the TTY (BE CAREFUL) [$GOTTY_PERMIT_WRITE]

--- a/server/options.go
+++ b/server/options.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Options struct {
+	Command             string           `hcl:"command" flagName:"command" flagSName:"x" flagDescribe:"Command to run" default:""`
+	Args                string           `hcl:"args" flagName:"args" flagSName:"g" flagDescribe:"Command arguments" default:""`
 	Address             string           `hcl:"address" flagName:"address" flagSName:"a" flagDescribe:"IP address to listen" default:"0.0.0.0"`
 	Port                string           `hcl:"port" flagName:"port" flagSName:"p" flagDescribe:"Port number to liten" default:"8080"`
 	PermitWrite         bool             `hcl:"permit_write" flagName:"permit-write" flagSName:"w" flagDescribe:"Permit clients to write to the TTY (BE CAREFUL)" default:"false"`


### PR DESCRIPTION
Allow passing in command and arguments via config. Among other things, this simplifies writing a systemd config file as mentioned in #37 to run as a daemon.