### PR TITLE
Attempt to make hterm to ignore keyboard input after deactivate()

### DIFF
--- a/js/src/hterm.ts
+++ b/js/src/hterm.ts
@@ -78,7 +78,6 @@ export class Hterm {
         this.io.onVTKeystroke    = function(){};
         this.io.sendString       = function(){};
         this.io.onTerminalResize = function(){};
-        this.term.uninstallKeyboard();
     }
 
     reset(): void {


### PR DESCRIPTION
I can't find any other way to make hterm be 'inactive' after deactivate() call.
If you uninstall keyboard in .deactivate() - terminal window transforms into weird text editor.

Looks like installKeyboard() is an idempotent operation: subsequent calls cause the same effect to single call, so this change does not break WebTTY reconnect feature on connection close.