### PR TITLE
Correct websocket connection close

### DIFF
--- a/js/src/websocket.ts
+++ b/js/src/websocket.ts
@@ -52,9 +52,9 @@ export class Connection {
         }
     };
 
-    onClose(callback: () => void) {
+    onClose(callback: (code: number, reason: string, wasClean: boolean) => void) {
         this.bare.onclose = (event) => {
-            callback();
+            callback(event.code, event.reason, event.wasClean);
         };
     };
 }


### PR DESCRIPTION
The WebSocket protocol declares the connection close procedure and allows to provide client/server with additional information about the cause of connection termination.

This patch makes GoTTY server to folow this procedure and close connection gracefully with additional information about the cause of action.