### PR TITLE
Added functionality for custom url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --credential value, -c value  Credential for Basic Authentication (ex: user:pass, default disabled) [$GOTTY_CREDENTIAL]
 --random-url, -r              Add a random string to the URL [$GOTTY_RANDOM_URL]
 --random-url-length value     Random URL length (default: 8) [$GOTTY_RANDOM_URL_LENGTH]
+--custom-url, -u              Add a customized string to the URL
 --tls, -t                     Enable TLS/SSL [$GOTTY_TLS]
 --tls-crt value               TLS/SSL certificate file path (default: "~/.gotty.crt") [$GOTTY_TLS_CRT]
 --tls-key value               TLS/SSL key file path (default: "~/.gotty.key") [$GOTTY_TLS_KEY]

--- a/server/options.go
+++ b/server/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	Credential          string           `hcl:"credential" flagName:"credential" flagSName:"c" flagDescribe:"Credential for Basic Authentication (ex: user:pass, default disabled)" default:""`
 	EnableRandomUrl     bool             `hcl:"enable_random_url" flagName:"random-url" flagSName:"r" flagDescribe:"Add a random string to the URL" default:"false"`
 	RandomUrlLength     int              `hcl:"random_url_length" flagName:"random-url-length" flagDescribe:"Random URL length" default:"8"`
+	CustomUrl           string           `hcl:"custom_url" flagName:"custom-url" flagSName:"u" flagDescribe:"Custom URL" defult:""`
 	EnableTLS           bool             `hcl:"enable_tls" flagName:"tls" flagSName:"t" flagDescribe:"Enable TLS/SSL" default:"false"`
 	TLSCrtFile          string           `hcl:"tls_crt_file" flagName:"tls-crt" flagDescribe:"TLS/SSL certificate file path" default:"~/.gotty.crt"`
 	TLSKeyFile          string           `hcl:"tls_key_file" flagName:"tls-key" flagDescribe:"TLS/SSL key file path" default:"~/.gotty.key"`

--- a/server/server.go
+++ b/server/server.go
@@ -100,7 +100,7 @@ func (server *Server) Run(ctx context.Context, options ...RunOption) error {
 		path += randomstring.Generate(server.options.RandomUrlLength) + "/"
 	} 
 	if server.options.CustomUrl != "" {
-		path += server.options.CustomUrl
+		path += server.options.CustomUrl + "/"
 	}
 
 	handlers := server.setupHandlers(cctx, cancel, path, counter)

--- a/server/server.go
+++ b/server/server.go
@@ -97,7 +97,10 @@ func (server *Server) Run(ctx context.Context, options ...RunOption) error {
 
 	path := "/"
 	if server.options.EnableRandomUrl {
-		path = "/" + randomstring.Generate(server.options.RandomUrlLength) + "/"
+		path += randomstring.Generate(server.options.RandomUrlLength) + "/"
+	} 
+	if server.options.CustomUrl != "" {
+		path += server.options.CustomUrl
 	}
 
 	handlers := server.setupHandlers(cctx, cancel, path, counter)


### PR DESCRIPTION
If the authentication is not done via a reverse proxy server before the gotty-server, then you can use a  random (but for the app known) secret url, to allow access to just this url. For this the "--custom-url" is meaingful. The same could maybe reached with nginx' "secure-link-module", see link below.
____
https://www.nginx.com/blog/securing-urls-secure-link-module-nginx-plus/