### PR TITLE
Fix typo in the port parameter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 
 ```
 --address value, -a value     IP address to listen (default: "0.0.0.0") [$GOTTY_ADDRESS]
---port value, -p value        Port number to liten (default: "8080") [$GOTTY_PORT]
+--port value, -p value        Port number to listen (default: "8080") [$GOTTY_PORT]
 --permit-write, -w            Permit clients to write to the TTY (BE CAREFUL) [$GOTTY_PERMIT_WRITE]
 --credential value, -c value  Credential for Basic Authentication (ex: user:pass, default disabled) [$GOTTY_CREDENTIAL]
 --random-url, -r              Add a random string to the URL [$GOTTY_RANDOM_URL]

--- a/server/options.go
+++ b/server/options.go
@@ -6,7 +6,7 @@ import (
 
 type Options struct {
 	Address             string           `hcl:"address" flagName:"address" flagSName:"a" flagDescribe:"IP address to listen" default:"0.0.0.0"`
-	Port                string           `hcl:"port" flagName:"port" flagSName:"p" flagDescribe:"Port number to liten" default:"8080"`
+	Port                string           `hcl:"port" flagName:"port" flagSName:"p" flagDescribe:"Port number to listen" default:"8080"`
 	PermitWrite         bool             `hcl:"permit_write" flagName:"permit-write" flagSName:"w" flagDescribe:"Permit clients to write to the TTY (BE CAREFUL)" default:"false"`
 	EnableBasicAuth     bool             `hcl:"enable_basic_auth" default:"false"`
 	Credential          string           `hcl:"credential" flagName:"credential" flagSName:"c" flagDescribe:"Credential for Basic Authentication (ex: user:pass, default disabled)" default:""`


### PR DESCRIPTION
From 'liten' to 'listen'