### PR TITLE
Adding support for pushing GoTTY to Cloud Foundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ By default, GoTTY starts a web server at port 8080. Open the URL on your web bro
 --height value                Static height of the screen, 0(default) means dynamically resize (default: 0) [$GOTTY_HEIGHT]
 --ws-origin value             A regular expression that matches origin URLs to be accepted by WebSocket. No cross origin requests are acceptable by default [$GOTTY_WS_ORIGIN]
 --term value                  Terminal name to use on the browser, one of xterm or hterm. (default: "xterm") [$GOTTY_TERM]
+--ws-port value               Specify a non-default WebSocket port for use from the browser back to GoTTY. [$GOTTY_WS_PORT]
 --close-signal value          Signal sent to the command process when gotty close it (default: SIGHUP) (default: 1) [$GOTTY_CLOSE_SIGNAL]
 --close-timeout value         Time in seconds to force kill process after client is disconnected (default: -1) (default: -1) [$GOTTY_CLOSE_TIMEOUT]
 --config value                Config file path (default: "~/.gotty") [$GOTTY_CONFIG]
@@ -163,6 +164,32 @@ make
 ```
 
 To build the frontend part (JS files and other static files), you need `npm`.
+
+## Deploying to Cloud Foundry
+
+You can deploy GoTTY to Cloud Foundry.  Either grab the linux-amd64 release from the GitHub repo and use that for deployment, or follow the build instructions above, and instead call `make cross_compile` to get the linux-amd64 binary.
+
+Copy the binary to a new directory by itself that you will "push" into Cloud Foundry.
+
+See below for how to push GoTTY using one of the example manifest files in this project.
+
+### Pivotal Web Services
+
+You could push to Pivotal Web Services using the following command:
+
+```sh
+cf push -f manifest-pws.yml -p <directory-containing-linux-amd64-gotty-executable>
+```
+
+Note: The manifest in this example sets the appropriate port for Secure WebSockets in PWS (4443), and GoTTY is only usable via HTTPS on Pivotal Web Services. 
+
+### Other Cloud Foundry Instances
+
+For other Cloud Foundry Instances, you may need to set additional parameters, but you can use the following command to get started:
+
+```sh
+cf push -f manifest-cf.yml -p <directory-containing-linux-amd64-gotty-executable>
+```
 
 ## Architecture
 

--- a/js/src/main.ts
+++ b/js/src/main.ts
@@ -6,6 +6,7 @@ import { ConnectionFactory } from "./websocket";
 // @TODO remove these
 declare var gotty_auth_token: string;
 declare var gotty_term: string;
+declare var gotty_wsport: string;
 
 const elem = document.getElementById("terminal")
 
@@ -17,7 +18,7 @@ if (elem !== null) {
         term = new Xterm(elem);
     }
     const httpsEnabled = window.location.protocol == "https:";
-    const url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + window.location.pathname + 'ws';
+    const url = (httpsEnabled ? 'wss://' : 'ws://') + window.location.host + (gotty_wsport != "" ? ":" + gotty_wsport : "")  + window.location.pathname + 'ws';
     const args = window.location.search;
     const factory = new ConnectionFactory(url, protocols);
     const wt = new WebTTY(term, factory, args, gotty_auth_token);

--- a/manifest-cf.yml
+++ b/manifest-cf.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: gotty
+  buildpack: binary_buildpack
+  command: ./gotty --port $PORT /bin/bash
+  path: builds/pkg/linux_amd64
+  env:
+    GOTTY_PERMIT_WRITE: true

--- a/manifest-pws.yml
+++ b/manifest-pws.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: gotty
+  buildpack: binary_buildpack
+  command: ./gotty --port $PORT /bin/bash
+  path: builds/pkg/linux_amd64
+  env:
+    GOTTY_WS_ORIGIN: '[^\.]*\.cfapps\.io'
+    GOTTY_WS_PORT: 4443
+    GOTTY_PERMIT_WRITE: true

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -209,7 +209,7 @@ func (server *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 func (server *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/javascript")
 	w.Write([]byte("var gotty_term = '" + server.options.Term + "';"))
-	w.Write([]byte("var gotty_wsport = ' + server.options.WSPort + "';"))
+	w.Write([]byte("var gotty_wsport = '" + server.options.WSPort + "';"))
 }
 
 // titleVariables merges maps in a specified order.

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -209,6 +209,7 @@ func (server *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 func (server *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/javascript")
 	w.Write([]byte("var gotty_term = '" + server.options.Term + "';"))
+	w.Write([]byte("var gotty_wsport = ' + server.options.WSPort + "';"))
 }
 
 // titleVariables merges maps in a specified order.

--- a/server/options.go
+++ b/server/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	Height              int              `hcl:"height" flagName:"height" flagDescribe:"Static height of the screen, 0(default) means dynamically resize" default:"0"`
 	WSOrigin            string           `hcl:"ws_origin" flagName:"ws-origin" flagDescribe:"A regular expression that matches origin URLs to be accepted by WebSocket. No cross origin requests are acceptable by default" default:""`
 	Term                string           `hcl:"term" flagName:"term" flagDescribe:"Terminal name to use on the browser, one of xterm or hterm." default:"xterm"`
+        WSPort              string           `hcl:"wsport" flagName:"wsport" flagDescribe:"Specify a non-default WebSocket port for use from the browser back to GoTTY." default:""`
 
 	TitleVariables map[string]interface{}
 }

--- a/server/options.go
+++ b/server/options.go
@@ -30,7 +30,7 @@ type Options struct {
 	Height              int              `hcl:"height" flagName:"height" flagDescribe:"Static height of the screen, 0(default) means dynamically resize" default:"0"`
 	WSOrigin            string           `hcl:"ws_origin" flagName:"ws-origin" flagDescribe:"A regular expression that matches origin URLs to be accepted by WebSocket. No cross origin requests are acceptable by default" default:""`
 	Term                string           `hcl:"term" flagName:"term" flagDescribe:"Terminal name to use on the browser, one of xterm or hterm." default:"xterm"`
-        WSPort              string           `hcl:"wsport" flagName:"wsport" flagDescribe:"Specify a non-default WebSocket port for use from the browser back to GoTTY." default:""`
+        WSPort              string           `hcl:"ws_port" flagName:"ws-port" flagDescribe:"Specify a non-default WebSocket port for use from the browser back to GoTTY." default:""`
 
 	TitleVariables map[string]interface{}
 }


### PR DESCRIPTION
Added in support for specifying a particular port to use for WebSockets (needed for Pivotal Web Services), and also added in some examples for how to push GoTTY to PWS and other Cloud Foundry instances.