### PR TITLE
Fix error format strings according to best practices from CodeReviewComments

### DIFF
--- a/server/asset.go
+++ b/server/asset.go
@@ -26,7 +26,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -34,7 +34,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("Read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 	if clErr != nil {
 		return nil, err


### PR DESCRIPTION
Use [CodeLingo](https://codelingo.io) to automatically fix function comments following the
[Go Code Review Comments guidelines](https://github.com/golang/go/wiki/CodeReviewComments) in [CONTRIBUTING.md](https://github.com/yudai/gotty/blob/master/CONTRIBUTING.md).

This patch was generated by running the CodeLingo Rewrite Flow over the "[go-error-fmt](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/code-review-comments/go-error-fmt/codelingo.yaml)" Tenet. Note: the same Tenet can be used to automate PR reviews and generate contributor docs.

[Learn More](https://codelingo.io)

[Install](https://github.com/apps/codelingo)