### PR TITLE
Solaris support

### DIFF
--- a/vendor/github.com/kr/pty/ioctl.go
+++ b/vendor/github.com/kr/pty/ioctl.go
@@ -1,3 +1,5 @@
+// +build !windows,!solaris
+
 package pty
 
 import "syscall"

--- a/vendor/github.com/kr/pty/ioctl_solaris.go
+++ b/vendor/github.com/kr/pty/ioctl_solaris.go
@@ -1,0 +1,30 @@
+package pty
+
+import (
+	"golang.org/x/sys/unix"
+	"unsafe"
+)
+
+const (
+	// see /usr/include/sys/stropts.h
+	I_PUSH  = uintptr((int32('S')<<8 | 002))
+	I_STR   = uintptr((int32('S')<<8 | 010))
+	I_FIND  = uintptr((int32('S')<<8 | 013))
+	// see /usr/include/sys/ptms.h
+	ISPTM   = (int32('P') << 8) | 1
+	UNLKPT  = (int32('P') << 8) | 2
+	PTSSTTY = (int32('P') << 8) | 3
+	ZONEPT  = (int32('P') << 8) | 4
+	OWNERPT = (int32('P') << 8) | 5
+)
+
+type strioctl struct {
+	ic_cmd    int32
+	ic_timout int32
+	ic_len    int32
+	ic_dp     unsafe.Pointer
+}
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	return unix.IoctlSetInt(int(fd), uint(cmd), int(ptr))
+}

--- a/vendor/github.com/kr/pty/pty_darwin.go
+++ b/vendor/github.com/kr/pty/pty_darwin.go
@@ -8,23 +8,28 @@ import (
 )
 
 func open() (pty, tty *os.File, err error) {
-	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	pFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, nil, err
 	}
+	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = grantpt(p)
-	if err != nil {
+	if err := grantpt(p); err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_dragonfly.go
+++ b/vendor/github.com/kr/pty/pty_dragonfly.go
@@ -1,0 +1,80 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// same code as pty_darwin.go
+func open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := grantpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	if err := unlockpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func grantpt(f *os.File) error {
+	_, err := isptmaster(f.Fd())
+	return err
+}
+
+func unlockpt(f *os.File) error {
+	_, err := isptmaster(f.Fd())
+	return err
+}
+
+func isptmaster(fd uintptr) (bool, error) {
+	err := ioctl(fd, syscall.TIOCISPTMASTER, 0)
+	return err == nil, err
+}
+
+var (
+	emptyFiodgnameArg fiodgnameArg
+	ioctl_FIODNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+)
+
+func ptsname(f *os.File) (string, error) {
+	name := make([]byte, _C_SPECNAMELEN)
+	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
+
+	err := ioctl(f.Fd(), ioctl_FIODNAME, uintptr(unsafe.Pointer(&fa)))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range name {
+		if c == 0 {
+			s := "/dev/" + string(name[:i])
+			return strings.Replace(s, "ptm", "pts", -1), nil
+		}
+	}
+	return "", errors.New("TIOCPTYGNAME string not NUL-terminated")
+}

--- a/vendor/github.com/kr/pty/pty_freebsd.go
+++ b/vendor/github.com/kr/pty/pty_freebsd.go
@@ -7,22 +7,28 @@ import (
 	"unsafe"
 )
 
-func posix_openpt(oflag int) (fd int, err error) {
+func posixOpenpt(oflag int) (fd int, err error) {
 	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
 	fd = int(r0)
 	if e1 != 0 {
 		err = e1
 	}
-	return
+	return fd, err
 }
 
 func open() (pty, tty *os.File, err error) {
-	fd, err := posix_openpt(syscall.O_RDWR | syscall.O_CLOEXEC)
+	fd, err := posixOpenpt(syscall.O_RDWR | syscall.O_CLOEXEC)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	p := os.NewFile(uintptr(fd), "/dev/pts")
+	// In case of error after this point, make sure we close the pts fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
@@ -42,7 +48,7 @@ func isptmaster(fd uintptr) (bool, error) {
 
 var (
 	emptyFiodgnameArg fiodgnameArg
-	ioctl_FIODGNAME   = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+	ioctlFIODGNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
 )
 
 func ptsname(f *os.File) (string, error) {
@@ -59,8 +65,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	err = ioctl(f.Fd(), ioctl_FIODGNAME, uintptr(unsafe.Pointer(&arg)))
-	if err != nil {
+	if err := ioctl(f.Fd(), ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
 		return "", err
 	}
 

--- a/vendor/github.com/kr/pty/pty_linux.go
+++ b/vendor/github.com/kr/pty/pty_linux.go
@@ -12,14 +12,19 @@ func open() (pty, tty *os.File, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
 
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = unlockpt(p)
-	if err != nil {
+	if err := unlockpt(p); err != nil {
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/kr/pty/pty_openbsd.go
+++ b/vendor/github.com/kr/pty/pty_openbsd.go
@@ -1,0 +1,33 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	/*
+	 * from ptm(4):
+	 * The PTMGET command allocates a free pseudo terminal, changes its
+	 * ownership to the caller, revokes the access privileges for all previous
+	 * users, opens the file descriptors for the master and slave devices and
+	 * returns them to the caller in struct ptmget.
+	 */
+
+	p, err := os.OpenFile("/dev/ptm", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer p.Close()
+
+	var ptm ptmget
+	if err := ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+		return nil, nil, err
+	}
+
+	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
+	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+
+	return pty, tty, nil
+}

--- a/vendor/github.com/kr/pty/pty_solaris.go
+++ b/vendor/github.com/kr/pty/pty_solaris.go
@@ -1,0 +1,139 @@
+package pty
+
+/* based on:
+http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libc/port/gen/pt.c
+*/
+
+import (
+	"errors"
+	"golang.org/x/sys/unix"
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+const NODEV = ^uint64(0)
+
+func open() (pty, tty *os.File, err error) {
+	masterfd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|unix.O_NOCTTY, 0)
+	//masterfd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC|unix.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := os.NewFile(uintptr(masterfd), "/dev/ptmx")
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = grantpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = unlockpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	slavefd, err := syscall.Open(sname, os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	t := os.NewFile(uintptr(slavefd), sname)
+
+	// pushing terminal driver STREAMS modules as per pts(7)
+	for _, mod := range([]string{"ptem", "ldterm", "ttcompat"}) {
+		err = streams_push(t, mod)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	
+	return p, t, nil
+}
+
+func minor(x uint64) uint64 {
+	return x & 0377
+}
+
+func ptsdev(fd uintptr) uint64 {
+	istr := strioctl{ISPTM, 0, 0, nil}
+	err := ioctl(fd, I_STR, uintptr(unsafe.Pointer(&istr)))
+	if err != nil {
+		return NODEV
+	}
+	var status unix.Stat_t
+	err = unix.Fstat(int(fd), &status)
+	if err != nil {
+		return NODEV
+	}
+	return uint64(minor(status.Rdev))
+}
+
+func ptsname(f *os.File) (string, error) {
+	dev := ptsdev(f.Fd())
+	if dev == NODEV {
+		return "", errors.New("not a master pty")
+	}
+	fn := "/dev/pts/" + strconv.FormatInt(int64(dev), 10)
+	// access(2) creates the slave device (if the pty exists)
+	// F_OK == 0 (unistd.h)
+	err := unix.Access(fn, 0)
+	if err != nil {
+		return "", err
+	}
+	return fn, nil
+}
+
+type pt_own struct {
+	pto_ruid int32
+	pto_rgid int32
+}
+
+func grantpt(f *os.File) error {
+	if ptsdev(f.Fd()) == NODEV {
+		return errors.New("not a master pty")
+	}
+	var pto pt_own
+	pto.pto_ruid = int32(os.Getuid())
+	// XXX should first attempt to get gid of DEFAULT_TTY_GROUP="tty"
+	pto.pto_rgid = int32(os.Getgid())
+	var istr strioctl
+	istr.ic_cmd = OWNERPT
+	istr.ic_timout = 0
+	istr.ic_len = int32(unsafe.Sizeof(istr))
+	istr.ic_dp = unsafe.Pointer(&pto)
+	err := ioctl(f.Fd(), I_STR, uintptr(unsafe.Pointer(&istr)))
+	if err != nil {
+		return errors.New("access denied")
+	}
+	return nil
+}
+
+func unlockpt(f *os.File) error {
+	istr := strioctl{UNLKPT, 0, 0, nil}
+	return ioctl(f.Fd(), I_STR, uintptr(unsafe.Pointer(&istr)))
+}
+
+// push STREAMS modules if not already done so
+func streams_push(f *os.File, mod string) error {
+	var err error
+	buf := []byte(mod)
+	// XXX I_FIND is not returning an error when the module
+	// is already pushed even though truss reports a return
+	// value of 1. A bug in the Go Solaris syscall interface?
+	// XXX without this we are at risk of the issue
+	// https://www.illumos.org/issues/9042
+	// but since we are not using libc or XPG4.2, we should not be
+	// double-pushing modules
+	
+	err = ioctl(f.Fd(), I_FIND, uintptr(unsafe.Pointer(&buf[0])))
+	if err != nil {
+		return nil
+	}
+	err = ioctl(f.Fd(), I_PUSH, uintptr(unsafe.Pointer(&buf[0])))
+	return err
+}

--- a/vendor/github.com/kr/pty/pty_unsupported.go
+++ b/vendor/github.com/kr/pty/pty_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd
+// +build !linux,!darwin,!freebsd,!dragonfly,!openbsd,!solaris
 
 package pty
 

--- a/vendor/github.com/kr/pty/run.go
+++ b/vendor/github.com/kr/pty/run.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package pty
 
 import (
@@ -10,15 +12,35 @@ import (
 // and c.Stderr, calls c.Start, and returns the File of the tty's
 // corresponding pty.
 func Start(c *exec.Cmd) (pty *os.File, err error) {
+	return StartWithSize(c, nil)
+}
+
+// StartWithSize assigns a pseudo-terminal tty os.File to c.Stdin, c.Stdout,
+// and c.Stderr, calls c.Start, and returns the File of the tty's
+// corresponding pty.
+//
+// This will resize the pty to the specified size before starting the command
+func StartWithSize(c *exec.Cmd, sz *Winsize) (pty *os.File, err error) {
 	pty, tty, err := Open()
 	if err != nil {
 		return nil, err
 	}
 	defer tty.Close()
+	if sz != nil {
+		err = Setsize(pty, sz)
+		if err != nil {
+			pty.Close()
+			return nil, err
+		}
+	}
 	c.Stdout = tty
 	c.Stdin = tty
 	c.Stderr = tty
-	c.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setctty = true
+	c.SysProcAttr.Setsid = true
 	err = c.Start()
 	if err != nil {
 		pty.Close()

--- a/vendor/github.com/kr/pty/types_dragonfly.go
+++ b/vendor/github.com/kr/pty/types_dragonfly.go
@@ -1,0 +1,17 @@
+// +build ignore
+
+package pty
+
+/*
+#define _KERNEL
+#include <sys/conf.h>
+#include <sys/param.h>
+#include <sys/filio.h>
+*/
+import "C"
+
+const (
+	_C_SPECNAMELEN = C.SPECNAMELEN /* max length of devicename */
+)
+
+type fiodgnameArg C.struct_fiodname_args

--- a/vendor/github.com/kr/pty/types_openbsd.go
+++ b/vendor/github.com/kr/pty/types_openbsd.go
@@ -1,0 +1,14 @@
+// +build ignore
+
+package pty
+
+/*
+#include <sys/time.h>
+#include <stdlib.h>
+#include <sys/tty.h>
+*/
+import "C"
+
+type ptmget C.struct_ptmget
+
+var ioctl_PTMGET = C.PTMGET

--- a/vendor/github.com/kr/pty/util.go
+++ b/vendor/github.com/kr/pty/util.go
@@ -1,3 +1,5 @@
+// +build !windows,!solaris
+
 package pty
 
 import (
@@ -6,26 +8,53 @@ import (
 	"unsafe"
 )
 
+// InheritSize applies the terminal size of master to slave. This should be run
+// in a signal handler for syscall.SIGWINCH to automatically resize the slave when
+// the master receives a window size change notification.
+func InheritSize(master, slave *os.File) error {
+	size, err := GetsizeFull(master)
+	if err != nil {
+		return err
+	}
+	err = Setsize(slave, size)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Setsize resizes t to s.
+func Setsize(t *os.File, ws *Winsize) error {
+	return windowRectCall(ws, t.Fd(), syscall.TIOCSWINSZ)
+}
+
+// GetsizeFull returns the full terminal size description.
+func GetsizeFull(t *os.File) (size *Winsize, err error) {
+	var ws Winsize
+	err = windowRectCall(&ws, t.Fd(), syscall.TIOCGWINSZ)
+	return &ws, err
+}
+
 // Getsize returns the number of rows (lines) and cols (positions
 // in each line) in terminal t.
 func Getsize(t *os.File) (rows, cols int, err error) {
-	var ws winsize
-	err = windowrect(&ws, t.Fd())
-	return int(ws.ws_row), int(ws.ws_col), err
+	ws, err := GetsizeFull(t)
+	return int(ws.Rows), int(ws.Cols), err
 }
 
-type winsize struct {
-	ws_row    uint16
-	ws_col    uint16
-	ws_xpixel uint16
-	ws_ypixel uint16
+// Winsize describes the terminal size.
+type Winsize struct {
+	Rows uint16 // ws_row: Number of rows (in cells)
+	Cols uint16 // ws_col: Number of columns (in cells)
+	X    uint16 // ws_xpixel: Width in pixels
+	Y    uint16 // ws_ypixel: Height in pixels
 }
 
-func windowrect(ws *winsize, fd uintptr) error {
+func windowRectCall(ws *Winsize, fd, a2 uintptr) error {
 	_, _, errno := syscall.Syscall(
 		syscall.SYS_IOCTL,
 		fd,
-		syscall.TIOCGWINSZ,
+		a2,
 		uintptr(unsafe.Pointer(ws)),
 	)
 	if errno != 0 {

--- a/vendor/github.com/kr/pty/util_solaris.go
+++ b/vendor/github.com/kr/pty/util_solaris.go
@@ -1,0 +1,51 @@
+//
+
+package pty
+
+import (
+	"os"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	TIOCGWINSZ = 21608 // 'T' << 8 | 104
+	TIOCSWINSZ = 21607 // 'T' << 8 | 103
+)
+
+// Winsize describes the terminal size.
+type Winsize struct {
+	Rows uint16 // ws_row: Number of rows (in cells)
+	Cols uint16 // ws_col: Number of columns (in cells)
+	X    uint16 // ws_xpixel: Width in pixels
+	Y    uint16 // ws_ypixel: Height in pixels
+}
+
+// GetsizeFull returns the full terminal size description.
+func GetsizeFull(t *os.File) (size *Winsize, err error) {
+	var wsz *unix.Winsize
+	wsz, err = unix.IoctlGetWinsize(int(t.Fd()), TIOCGWINSZ)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return &Winsize{wsz.Row, wsz.Col, wsz.Xpixel, wsz.Ypixel}, nil
+	}
+}
+
+// Get Windows Size
+func Getsize(t *os.File) (rows, cols int, err error) {
+	var wsz *unix.Winsize
+	wsz, err = unix.IoctlGetWinsize(int(t.Fd()), TIOCGWINSZ)
+
+	if err != nil {
+		return 80, 25, err
+	} else {
+		return int(wsz.Row), int(wsz.Col), nil
+	}
+}
+
+// Setsize resizes t to s.
+func Setsize(t *os.File, ws *Winsize) error {
+	wsz := unix.Winsize{ws.Rows, ws.Cols, ws.X, ws.Y}
+	return unix.IoctlSetWinsize(int(t.Fd()), TIOCSWINSZ, &wsz)
+}

--- a/vendor/github.com/kr/pty/ztypes_dragonfly_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_dragonfly_amd64.go
@@ -1,0 +1,14 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_dragonfly.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Name      *byte
+	Len       uint32
+	Pad_cgo_0 [4]byte
+}

--- a/vendor/github.com/kr/pty/ztypes_mipsx.go
+++ b/vendor/github.com/kr/pty/ztypes_mipsx.go
@@ -1,0 +1,12 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+// +build linux
+// +build mips mipsle mips64 mips64le
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_openbsd_386.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_386.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd	int32
+	Sfd	int32
+	Cn	[16]int8
+	Sn	[16]int8
+}
+
+var ioctl_PTMGET = 0x40287401

--- a/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd int32
+	Sfd int32
+	Cn  [16]int8
+	Sn  [16]int8
+}
+
+var ioctl_PTMGET = 0x40287401


### PR DESCRIPTION
I implemented Solaris support in kr/pty (see https://github.com/kr/pty/pull/64) using gotty as a test harness. I did change the function ResizeTerminal in local_command.go to use pty.Setsize, an equivalent implementation that was added to kr/pty (and which works on Solaris).

Verified on SmartOS 20170302T081240Z amd64 with Go 1.11.4.