### PR TITLE
Enable websocket cross-origin while ws_origin is set as ""

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -66,6 +66,10 @@ func New(factory Factory, options *Options) (*Server, error) {
 		originChekcer = func(r *http.Request) bool {
 			return matcher.MatchString(r.Header.Get("Origin"))
 		}
+	} else {
+		originChekcer = func(r *http.Request) bool {
+			return true
+		}
 	}
 
 	return &Server{


### PR DESCRIPTION
Hi Dai,

Gotty is an awesome project and I like it very much, but it seems that there is something unexpected, maybe.
By design , if the flag "ws_origin"  is set as "", there should be no cross-origin check for websocket.
But actually if we pass a nil function as CheckOrigin for websocket.Upgradter,  the host in the Origin header must not be set or must match the host of the request.
So my change is, if "ws_origin"  is set as "", ChechOrigin will be a func who always return  true.
Please kindly correct me if my usage went wrong.

BR,
Ye Jianquan
