### PR TITLE
Fix printing ipv6 with brackets

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -127,10 +127,10 @@ func (server *Server) Run(ctx context.Context, options ...RunOption) error {
 		scheme = "https"
 	}
 	host, port, _ := net.SplitHostPort(listener.Addr().String())
-	log.Printf("HTTP server is listening at: %s", scheme+"://"+host+":"+port+path)
+	log.Printf("HTTP server is listening at: %s", scheme+"://"+net.JoinHostPort(host, port)+path)
 	if server.options.Address == "0.0.0.0" {
 		for _, address := range listAddresses() {
-			log.Printf("Alternative URL: %s", scheme+"://"+address+":"+port+path)
+			log.Printf("Alternative URL: %s", scheme+"://"+net.JoinHostPort(address, port)+path)
 		}
 	}
 


### PR DESCRIPTION
It was fixed in #42, but is broken now. This PR prints ipv6 in the format, which can be opened in a browser:

```
>±> ./gotty zsh
2019/12/30 13:54:18 GoTTY is starting with command: zsh
2019/12/30 13:54:18 HTTP server is listening at: http://[::]:8080/
2019/12/30 13:54:18 Alternative URL: http://127.0.0.1:8080/
2019/12/30 13:54:18 Alternative URL: http://[::1]:8080/
2019/12/30 13:54:18 Alternative URL: http://[fe80::2ba1:dd5e:2dd9:9d75]:8080/
2019/12/30 13:54:18 Alternative URL: http://172.0.0.207:8080/
2019/12/30 13:54:18 Alternative URL: http://[fe80::f81d:ef8:fea5:f9f5]:8080/
```