### PR TITLE
fix typo in protocol description of message_types.go .

### DIFF
--- a/webtty/message_types.go
+++ b/webtty/message_types.go
@@ -1,7 +1,7 @@
 package webtty
 
 // Protocols defines the name of this protocol,
-// which is supposed to be used to the subprotocol of Websockt streams.
+// which is supposed to be used to the subprotocol of Websocket streams.
 var Protocols = []string{"webtty"}
 
 const (


### PR DESCRIPTION
From 'Websockt' to 'Websocket'.