### PR TITLE
Read all payloads from reader at once

### DIFF
--- a/server/ws_wrapper.go
+++ b/server/ws_wrapper.go
@@ -19,7 +19,7 @@ func (wsw *wsWrapper) Write(p []byte) (n int, err error) {
 
 func (wsw *wsWrapper) Read(p []byte) (n int, err error) {
 	for {
-		msgType, reader, err := wsw.Conn.NextReader()
+		msgType, bytes, err := wsw.Conn.ReadMessage()
 		if err != nil {
 			return 0, err
 		}
@@ -28,6 +28,7 @@ func (wsw *wsWrapper) Read(p []byte) (n int, err error) {
 			continue
 		}
 
-		return reader.Read(p)
+		copy(p, bytes)
+		return len(bytes), err
 	}
 }

--- a/server/ws_wrapper.go
+++ b/server/ws_wrapper.go
@@ -17,6 +17,14 @@ func (wsw *wsWrapper) Write(p []byte) (n int, err error) {
 	return writer.Write(p)
 }
 
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
 func (wsw *wsWrapper) Read(p []byte) (n int, err error) {
 	for {
 		msgType, bytes, err := wsw.Conn.ReadMessage()
@@ -29,6 +37,6 @@ func (wsw *wsWrapper) Read(p []byte) (n int, err error) {
 		}
 
 		copy(p, bytes)
-		return len(bytes), err
+		return minInt(len(p), len(bytes)), err
 	}
 }


### PR DESCRIPTION
Reader might return before finish reading all pending bytes. This might cause event handling to fail randomly.

Signed-off-by: Xiaoguang Sun <sunxiaoguang@gmail.com>